### PR TITLE
feat: support url extraction from img tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__
+
+.idea/*
+*.egg-info

--- a/src/sulguk/transformer.py
+++ b/src/sulguk/transformer.py
@@ -64,13 +64,18 @@ class Transformer(HTMLParser):
     def _get_classes(self, attrs: Attrs):
         return self._find_attr("class", attrs).split()
 
-    def _get_url(self, attrs: Attrs) -> Entity:
-        for name in ('href', 'src'):
-            url = self._find_attr(name, attrs)
-            if url:
-                return Link(url=url)
+    def _get_a(self, attrs: Attrs) -> Entity:
+        url = self._find_attr('href', attrs)
+        if url:
+            return Link(url=url)
         return Group()
-
+    
+    def _get_img(self, attrs: Attrs) -> Entity:
+        url = self._find_attr('src', attrs)
+        if url:
+            return Link(url=url)
+        return Group()
+    
     def _get_ul(self, attrs: Attrs) -> Entity:
         return ListGroup(numbered=False)
 
@@ -203,8 +208,10 @@ class Transformer(HTMLParser):
             nested = entity = self._get_ol(attrs)
         elif tag in ("li",):
             nested = entity = self._get_li(attrs)
-        elif tag in ("a", 'img'):
-            nested = entity = self._get_url(attrs)
+        elif tag in ("a", ):
+            nested = entity = self._get_a(attrs)
+        elif tag in ("img",):
+            nested = entity = self._get_img(attrs)
         elif tag in ("b", "strong"):
             nested = entity = Bold()
         elif tag in ("i", "em", "cite", "var"):

--- a/src/sulguk/transformer.py
+++ b/src/sulguk/transformer.py
@@ -64,12 +64,12 @@ class Transformer(HTMLParser):
     def _get_classes(self, attrs: Attrs):
         return self._find_attr("class", attrs).split()
 
-    def _get_a(self, attrs: Attrs) -> Entity:
-        url = self._find_attr("href", attrs)
-        if url:
-            return Link(url=url)
-        else:
-            return Group()
+    def _get_url(self, attrs: Attrs) -> Entity:
+        for name in ('href', 'src'):
+            url = self._find_attr(name, attrs)
+            if url:
+                return Link(url=url)
+        return Group()
 
     def _get_ul(self, attrs: Attrs) -> Entity:
         return ListGroup(numbered=False)
@@ -203,8 +203,8 @@ class Transformer(HTMLParser):
             nested = entity = self._get_ol(attrs)
         elif tag in ("li",):
             nested = entity = self._get_li(attrs)
-        elif tag in ("a",):
-            nested = entity = self._get_a(attrs)
+        elif tag in ("a", 'img'):
+            nested = entity = self._get_url(attrs)
         elif tag in ("b", "strong"):
             nested = entity = Bold()
         elif tag in ("i", "em", "cite", "var"):

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -45,6 +45,8 @@ PRE_PLAIN = "1\n\n    2\n\n3"
 PRE_P_HTML = "<p>1</p>\n<pre>\n    2</pre>"
 PRE_P_PLAIN = "1\n\n    2\n\n"
 
+IMG_HTML = '<img src="https://google.com">'
+IMG_URL = "https://google.com"
 
 @pytest.mark.parametrize("html, plain, name", [
     (SPACES_SPAN_HTML, SPACES_SPAN_PLAIN, "span"),
@@ -63,3 +65,16 @@ def test_spaces(html, plain, name):
     print(repr(plain))
     print(repr(html))
     assert result.text == plain
+
+
+
+@pytest.mark.parametrize("html, url", [
+    (IMG_HTML, IMG_URL),
+])
+def test_link_extracted(html, url):
+    result = transform_html(html)
+    assert result.text == ""
+    assert len(result.entities) == 1
+    entity = result.entities[0]
+    assert entity['type'] == 'text_link'
+    assert entity['url'] == url


### PR DESCRIPTION
Currently, extraction of link from `<img src="google.com" />` is not supported:
```bash
ValueError: Unsupported tag: img
```
With this contribution, the `img` tag is supported and casted to entity with `type='text_link'`