### PR TITLE
Added wbr tag support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__
 
 .idea/*
 *.egg-info
+
+build/*

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The same behavior is supported in sulguk. Otherwise, you can set the language on
 #### Additional tags:
 * `<br/>` - new line
 * `<hr/>` - horizontal line
+* `<wbr/>` - word break opportunity
 * `<ul>` - unordered list
 * `<ol>` - ordered list with optional attributes
     * `reversed` - to reverse numbers order

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ But this is how it is rendered in Telegram with `parse_mode="html"`:
 
 ![](https://github.com/tishka17/sulguk/blob/master/images/problem_telegram.png?raw=True)
 
-T osolve this we can convert HTML to telegram entites with `sulguk`. So that's how it looks now:
+To solve this we can convert HTML to telegram entities with `sulguk`. So that's how it looks now:
 
 ![](https://github.com/tishka17/sulguk/blob/master/images/problem_sulguk.png?raw=True)
 

--- a/example.html
+++ b/example.html
@@ -10,3 +10,6 @@
 <h3>Other features</h3>
 <Blockquote>This is block quote</Blockquote>
 <p>This is paragraph!</p><p>And one more with <q>quote</q>.</p>
+<p>The longest word in the German language: Donaudampfschifffahrtsgesellschaftskapitaenswitwe</p>
+<p>And again, the longest word in the German language:
+    Donau<wbr />dampf<wbr />schiff<wbr />fahrts<wbr />gesellschafts<wbr />kapitaens<wbr />witwe</p>

--- a/src/sulguk/entities/__init__.py
+++ b/src/sulguk/entities/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "ListItem",
     "NewLine",
     "HorizontalLine",
+    "ZeroWidthSpace",
     "Progress",
     "Stub",
     "Text",
@@ -41,7 +42,7 @@ from .decoration import (
 )
 from .emoji import Emoji
 from .list import ListGroup, ListItem
-from .no_contents import HorizontalLine, NewLine
+from .no_contents import HorizontalLine, NewLine, ZeroWidthSpace
 from .progress import Progress
 from .stub import Stub
 from .text import Text

--- a/src/sulguk/entities/no_contents.py
+++ b/src/sulguk/entities/no_contents.py
@@ -19,3 +19,8 @@ class HorizontalLine(NoContents):
         state.canvas.add_new_line_soft()
         state.canvas.add_text("⎯" * 10)
         state.canvas.add_new_line_soft()
+
+
+class ZeroWidthSpace(NoContents):
+    def render(self, state: State) -> None:
+        state.canvas.add_text("\u200b")

--- a/src/sulguk/transformer.py
+++ b/src/sulguk/transformer.py
@@ -25,6 +25,7 @@ from .entities import (
     Text,
     Underline,
     Uppercase,
+    ZeroWidthSpace,
 )
 
 Attrs = List[Tuple[str, Optional[str]]]
@@ -39,7 +40,7 @@ OL_FORMAT = {
 
 LANG_CLASS_PREFIX = "language-"
 
-NO_CLOSING_TAGS = ("br", "hr", "meta", "link", "img")
+NO_CLOSING_TAGS = ("br", "wbr", "hr", "meta", "link", "img")
 
 
 class Transformer(HTMLParser):
@@ -196,6 +197,8 @@ class Transformer(HTMLParser):
     def handle_startendtag(self, tag: str, attrs: Attrs) -> None:
         if tag == "br":
             entity = NewLine()
+        elif tag == "wbr":
+            entity = ZeroWidthSpace()
         elif tag == "hr":
             entity = HorizontalLine()
         elif tag in ("img",):


### PR DESCRIPTION
I have implemented support for the wbr tag using zero width space (ZWSP), but ZWSP is not displayed correctly on some clients:
+ On my phone (Telegram for Android v10.5.2 (4244)) everything works as it should
+ On my laptop (Telegram Desktop 4.14.3, Ubuntu, Snap) ZWSP turns into a regular space

Therefore, I do not understand whether this pull request should have been opened