### PR TITLE
Fix parse_mode for aiogram 3.4.1

### DIFF
--- a/src/sulguk/aiogram_middleware.py
+++ b/src/sulguk/aiogram_middleware.py
@@ -115,4 +115,6 @@ class AiogramSulgukMiddleware(BaseRequestMiddleware):
         parse_mode = getattr(method, "parse_mode", "")
         if parse_mode is UNSET_PARSE_MODE:
             parse_mode = bot.parse_mode
+        if isinstance(parse_mode, type(UNSET_PARSE_MODE)):
+            parse_mode = bot.default.parse_mode
         return parse_mode == SULGUK_PARSE_MODE


### PR DESCRIPTION
Fixed a bug in issues 28 related to parse_mode in aiogram 3.4.1.  The fixes support earlier versions of aiogram!